### PR TITLE
Add jsonb support

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -262,6 +262,7 @@ var init = function(register) {
   register(1186, parseInterval);
   register(17, parseByteA);
   register(114, JSON.parse.bind(JSON));
+  register(3802, JSON.parse.bind(JSON));
   register(199, parseJsonArray); // json[]
   register(2951, parseStringArray); // uuid[]
 };


### PR DESCRIPTION
Closes https://github.com/brianc/node-postgres/issues/658

I was going to point out that it wouldn't be testable until 9.4 leaves beta and then is available on Travis, but then again regular json isn't tested either
