### PR TITLE
Update textParser for Date objects

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -1,49 +1,68 @@
 var arrayParser = require(__dirname + "/arrayParser.js");
 
+var fullDateMatcher = /^(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?([Z+\-]([^\\w]*))?/;
+var dateOnlyMatcher = /^(\d{1,})-(\d{2})-(\d{2})/;
+
 //parses PostgreSQL server formatted date strings into javascript date objects
 var parseDate = function(isoDate) {
-  //TODO this could do w/ a refactor
-  var dateMatcher = /(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?/;
 
-  var match = dateMatcher.exec(isoDate);
-  //could not parse date
-  if(!match) {
-    dateMatcher = /^(\d{1,})-(\d{2})-(\d{2})$/;
-    match = dateMatcher.test(isoDate);
-    if(!match) {
+  var isFullDate = true;
+  var match = fullDateMatcher.exec(isoDate);
+  if (match === null) {
+    match = dateOnlyMatcher.exec(isoDate);
+    if (match === null) {
       return null;
-    } else {
-      //it is a date in YYYY-MM-DD format
-      //add time portion to force js to parse as local time
-      return new Date(isoDate + ' 00:00:00');
     }
+    isFullDate = false;
   }
+
+  var date;
   var isBC = /BC$/.test(isoDate);
   var _year = parseInt(match[1], 10);
   var isFirstCentury = (_year > 0) && (_year < 100);
   var year = (isBC ? "-" : "") + match[1];
-
   var month = parseInt(match[2],10)-1;
   var day = match[3];
-  var hour = parseInt(match[4],10);
-  var min = parseInt(match[5],10);
-  var seconds = parseInt(match[6], 10);
 
-  var miliString = match[7];
-  var mili = 0;
-  if(miliString) {
-    mili = 1000 * parseFloat(miliString);
+  if (isFullDate) {
+    var hour = parseInt(match[4],10);
+    var min = parseInt(match[5],10);
+    var seconds = parseInt(match[6], 10);
+
+    var miliString = match[7];
+    var mili = 0;
+    if (miliString) {
+      mili = 1000 * parseFloat(miliString);
+    }
+
+    if (match[8]) {
+      var tzAdjust = parseTimeZone(match[8]);
+      var utcOffset = Date.UTC(year, month, day, hour, min, seconds, mili);
+      date = new Date(utcOffset - (tzAdjust * 1000));
+    } else {
+      date = new Date(year, month, day, hour, min, seconds, mili);
+    }
+  } else {
+    date = new Date(year, month, day);
   }
 
-  //match timezones like the following:
-  //Z (UTC)
-  //-05
-  //+06:30
-  var tZone = /([Z|+\-])(\d{2})?:?(\d{2})?:?(\d{2})?/.exec(isoDate.split(' ')[1]);
+  if (isFirstCentury) {
+    date.setUTCFullYear(year);
+  }
+
+  return date;
+};
+
+//match timezones like the following:
+//Z (UTC)
+//-05
+//+06:30
+function parseTimeZone(zoneStr) {
+  var tZone = /([Z|+\-])(\d{2})?:?(\d{2})?:?(\d{2})?/.exec(zoneStr);
   //minutes to adjust for timezone
   var tzAdjust = 0;
   var tzSign = 1;
-  var date;
+
   if(tZone) {
     var type = tZone[1];
     switch(type) {
@@ -51,6 +70,7 @@ var parseDate = function(isoDate) {
       break;
     case '-':
       tzSign = -1;
+      // Deliberate fallthrough
     case '+':
       tzAdjust = tzSign * (
         (parseInt(tZone[2], 10) * 3600) +
@@ -61,22 +81,10 @@ var parseDate = function(isoDate) {
     default:
       throw new Error("Unidentifed tZone part " + type);
     }
-
-    var utcOffset = Date.UTC(year, month, day, hour, min, seconds, mili);
-
-    date = new Date(utcOffset - (tzAdjust * 1000));
+    return tzAdjust;
   }
-  //no timezone information
-  else {
-    date = new Date(year, month, day, hour, min, seconds, mili);
-  }
-
-  if (isFirstCentury) {
-    date.setUTCFullYear(year);
-  }
-
-  return date;
-};
+  return 0;
+}
 
 var parseBool = function(val) {
   if(val === null) return val;

--- a/test/dates.js
+++ b/test/dates.js
@@ -13,6 +13,13 @@ describe("date parser", function() {
     );
   });
 
+  it("parses date with more-standard formats", function() {
+    assert.equal(
+      parse("2010-12-11 09:09:04Z").toString(),
+      new Date("2010-12-11T09:09:04Z").toString()
+    );
+  });
+
   var testForMs = function(part, expected) {
     var dateString = "2010-01-01 01:01:01" + part;
     it("testing for correcting parsing of " + dateString, function() {


### PR DESCRIPTION
I ran in to trouble with Date parsing in this module because I have been working on Trireme (https://github.com/apigee/trireme) which is an alternate implementation of Node.js.

Trireme's JavaScript engine (Rhino) seems to interpret the default values when parsing Date strings differently than Node. I can try to track down the differences between Node and Rhino, and fix them in Rhino, but it's not clear to me at the moment that Node is necessarily "more correct."

Instead, I simplified the date parsing code and had it use methods that are less ambiguous about what they mean.

Can you take a look at this -- I think that it simplifies the code and does less harm so it's worth taking IMHO. Thank!