### PR TITLE
Allow interval objects to be passed back into prepared statments

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -160,10 +160,24 @@ var INTERVAL = [YEAR,MON,DAY,TIME].map(function(p){
   return "("+p+")?";
 }).join('\\s*');
 
+/* Wrapper object that makes sure Interval objects can be passed back
+ * into prepared statements */
+function PostgresInterval() {}
+PostgresInterval.prototype.toPostgres = function() {
+  var intervalElements = [];
+  if (this.seconds) intervalElements.push(this.seconds + ' seconds');
+  if (this.minutes) intervalElements.push(this.minutes + ' minutes');
+  if (this.hours)   intervalElements.push(this.hours   + ' hours');
+  if (this.days)    intervalElements.push(this.days    + ' days');
+  if (this.months)  intervalElements.push(this.months  + ' months');
+  if (this.years)   intervalElements.push(this.years   + ' years');
+  return intervalElements.join(' ');
+};
+
 var parseInterval = function(val) {
   if (!val) { return {}; }
   var m = new RegExp(INTERVAL).exec(val);
-  var i = {};
+  var i = new PostgresInterval();
   if (m[2]) { i.years = parseInt(m[2], 10); }
   if (m[4]) { i.months = parseInt(m[4], 10); }
   if (m[6]) { i.days = parseInt(m[6], 10); }

--- a/test/index.js
+++ b/test/index.js
@@ -124,6 +124,7 @@ var tests = [{
   dataTypeID: 1186,
   actual: '01:02:03',
   expected: function(val) {
+    assert.equal(val.toPostgres(), '3 seconds 2 minutes 1 hours');
     assert.deepEqual(val, {'hours':1, 'minutes':2, 'seconds':3});
   }
 },{
@@ -132,6 +133,7 @@ var tests = [{
   dataTypeID: 1186,
   actual: '1 year -32 days',
   expected: function(val) {
+    assert.equal(val.toPostgres(), '-32 days 1 years');
     assert.deepEqual(val, {'years':1, 'days':-32});
   }
 },{
@@ -140,6 +142,7 @@ var tests = [{
   dataTypeID: 1186,
   actual: '1 day -00:00:03',
   expected: function(val) {
+    assert.equal(val.toPostgres(), '-3 seconds 1 days');
     assert.deepEqual(val, {'days':1, 'seconds':-3});
   }
 },{


### PR DESCRIPTION
Currently node-postgres returns intervals in the form of ```{days: 12, hours: 2}```. Passing the same object back into a prepared statement causes strange behaviour and is normally not correct.

This PR should fix the issue by adding a ```toPostgres``` converter function to the object.