### PR TITLE
Adding millisecond support to interval columns

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -155,7 +155,7 @@ var NUM = '([+-]?\\d+)';
 var YEAR = NUM + '\\s+years?';
 var MON = NUM + '\\s+mons?';
 var DAY = NUM + '\\s+days?';
-var TIME = '([+-])?(\\d\\d):(\\d\\d):(\\d\\d)';
+var TIME = '([+-])?(\\d\\d):(\\d\\d):(\\d\\d):?(\\d\\d\\d)?';
 var INTERVAL = [YEAR,MON,DAY,TIME].map(function(p){
   return "("+p+")?";
 }).join('\\s*');
@@ -170,6 +170,7 @@ var parseInterval = function(val) {
   if (m[9]) { i.hours = parseInt(m[9], 10); }
   if (m[10]) { i.minutes = parseInt(m[10], 10); }
   if (m[11]) { i.seconds = parseInt(m[11], 10); }
+  if (m[12]) { i.milliseconds = parseInt(m[12], 10); }
   if (m[8] == '-'){
     if (i.hours) { i.hours *= -1; }
     if (i.minutes) { i.minutes *= -1; }

--- a/test/index.js
+++ b/test/index.js
@@ -127,6 +127,14 @@ var tests = [{
     assert.deepEqual(val, {'hours':1, 'minutes':2, 'seconds':3});
   }
 },{
+  name: 'interval time with milliseconds',
+  format: 'text',
+  dataTypeID: 1186,
+  actual: '01:02:03:456',
+  expected: function(val) {
+    assert.deepEqual(val, {'hours':1, 'minutes':2, 'seconds':3, 'milliseconds': 456});
+  }
+},{
   name: 'interval long',
   format: 'text',
   dataTypeID: 1186,


### PR DESCRIPTION
Intervals can optionally have a millisecond attribute. This adds support for it.

My Regex isn't perfect :(