### PR TITLE
Fixed interval parsing regex to support milliseconds

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -155,7 +155,7 @@ var NUM = '([+-]?\\d+)';
 var YEAR = NUM + '\\s+years?';
 var MON = NUM + '\\s+mons?';
 var DAY = NUM + '\\s+days?';
-var TIME = '([+-])?(\\d\\d):(\\d\\d):(\\d\\d):?(\\d\\d\\d)?';
+var TIME = '([+-])?(\\d\\d):(\\d\\d):(\\d\\d)[\.:]?(\\d\\d\\d)?';
 var INTERVAL = [YEAR,MON,DAY,TIME].map(function(p){
   return "("+p+")?";
 }).join('\\s*');


### PR DESCRIPTION
Intervals were getting parsed and turning up without milliseconds.

The milliseconds are actually separated from seconds place by a decimal (at least in my version of postgres). For example, see how the following sql prints output:

    # select '20 milliseconds'::interval;
      interval   
    -------------
     00:00:00.02
    (1 row)

Adding a decimal character to the regex adds support for this. I left the colon in there just in case postgres used to do this in previous versions?