### PR TITLE
This solves the error parsing arrays in the newest version

### DIFF
--- a/lib/arrayParser.js
+++ b/lib/arrayParser.js
@@ -3,7 +3,9 @@ var array = require('postgres-array');
 module.exports = {
   create: function (source, transform) {
     return {
-      parse: array.parse
+      parse: function() {
+        return array.parse(source, transform);
+      }
     };
   }
 };


### PR DESCRIPTION
Introduced by https://github.com/brianc/node-pg-types/commit/f0c931a3c9d034fc3bf9ffa32c05784629ab38aa

Not sure this is the best way of solving it. Annoyingly the tests didn't catch this one, that function might just not be covered. 