### PR TITLE
typos in textParser.js

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -29,14 +29,14 @@ function parseIntegerArray (value) {
 
 function parseBigIntegerArray (value) {
   if (!value) return null
-  return array.parse(val, allowNull(function (item) {
+  return array.parse(value, allowNull(function (item) {
     return parseBigInteger(entry).trim()
   }))
 }
 
-var parseFloatArray = function(val) {
-  if(!val) { return null; }
-  var p = arrayParser.create(val, function(entry) {
+var parseFloatArray = function(value) {
+  if(!value) { return null; }
+  var p = arrayParser.create(value, function(entry) {
     if(entry !== null) {
       entry = parseFloat(entry);
     }
@@ -46,17 +46,17 @@ var parseFloatArray = function(val) {
   return p.parse();
 };
 
-var parseStringArray = function(val) {
-  if(!val) { return null; }
+var parseStringArray = function(value) {
+  if(!value) { return null; }
 
-  var p = arrayParser.create(val);
+  var p = arrayParser.create(value);
   return p.parse();
 };
 
-var parseDateArray = function(val) {
-  if (!val) { return null; }
+var parseDateArray = function(value) {
+  if (!value) { return null; }
 
-  var p = arrayParser.create(val, function(entry) {
+  var p = arrayParser.create(value, function(entry) {
     if (entry !== null) {
       entry = parseDate(entry);
     }
@@ -66,8 +66,8 @@ var parseDateArray = function(val) {
   return p.parse();
 };
 
-var parseByteAArray = function(val) {
-  var arr = parseStringArray(val);
+var parseByteAArray = function(value) {
+  var arr = parseStringArray(value);
   if (!arr) return arr;
 
   return arr.map(function(element) {
@@ -75,18 +75,18 @@ var parseByteAArray = function(val) {
   });
 };
 
-var parseInteger = function(val) {
-  return parseInt(val, 10);
+var parseInteger = function(value) {
+  return parseInt(value, 10);
 };
 
-var parseBigInteger = function(val) {
-  var valStr = String(val);
+var parseBigInteger = function(value) {
+  var valStr = String(value);
   if (/^\d+$/.test(valStr)) { return valStr; }
-  return val;
+  return value;
 };
 
-var parseJsonArray = function(val) {
-  var arr = parseStringArray(val);
+var parseJsonArray = function(value) {
+  var arr = parseStringArray(value);
 
   if (!arr) {
     return arr;
@@ -95,40 +95,40 @@ var parseJsonArray = function(val) {
   return arr.map(function(el) { return JSON.parse(el); });
 };
 
-var parsePoint = function(val) {
-  if (val[0] !== '(') { return null; }
+var parsePoint = function(value) {
+  if (value[0] !== '(') { return null; }
 
-  val = val.substring( 1, val.length - 1 ).split(',');
+  value = value.substring( 1, value.length - 1 ).split(',');
 
   return {
-    x: parseFloat(val[0])
-  , y: parseFloat(val[1])
+    x: parseFloat(value[0])
+  , y: parseFloat(value[1])
   };
 };
 
-var parseCircle = function(val) {
-  if (val[0] !== '<' && val[1] !== '(') { return null; }
+var parseCircle = function(value) {
+  if (value[0] !== '<' && value[1] !== '(') { return null; }
 
   var point = '(';
   var radius = '';
   var pointParsed = false;
-  for (var i = 2; i < val.length - 1; i++){
+  for (var i = 2; i < value.length - 1; i++){
     if (!pointParsed) {
-      point += val[i];
+      point += value[i];
     }
 
-    if (val[i] === ')') {
+    if (value[i] === ')') {
       pointParsed = true;
       continue;
     } else if (!pointParsed) {
       continue;
     }
 
-    if (val[i] === ','){
+    if (value[i] === ','){
       continue;
     }
 
-    radius += val[i];
+    radius += value[i];
   }
   var result = parsePoint(point);
   result.radius = parseFloat(radius);

--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -29,7 +29,7 @@ function parseIntegerArray (value) {
 
 function parseBigIntegerArray (value) {
   if (!value) return null
-  return array.parse(value, allowNull(function (item) {
+  return array.parse(value, allowNull(function (entry) {
     return parseBigInteger(entry).trim()
   }))
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-types",
-  "version": "1.9.2",
+  "version": "1.9.0",
   "description": "Query result type converters for node-postgres",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-types",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Query result type converters for node-postgres",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-types",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Query result type converters for node-postgres",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
:fire: Fixed some breaking typos and standardizes variable names (val -> value in all cases).