### PR TITLE
Fix truncation of BIGINT within nested JSON

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -5,11 +5,21 @@ var parseDate = require('postgres-date');
 var parseInterval = require('postgres-interval');
 var parseByteA = require('postgres-bytea');
 
+var intToStringRegex = new RegExp('("[^"]+":\\s*)(-?\\d+)', 'g');
+
 function allowNull (fn) {
   return function nullAllowed (value) {
     if (value === null) return value
     return fn(value)
   }
+}
+
+function stringifyInts(jsonString) {
+  return jsonString.replace(intToStringRegex, "$1 \"$2\"");
+}
+
+function safeParseJson(json) {
+  return JSON.parse(stringifyInts(json));
 }
 
 function parseBool (value) {
@@ -81,7 +91,7 @@ var parseInteger = function(value) {
 
 var parseBigInteger = function(value) {
   var valStr = String(value);
-  if (/^\d+$/.test(valStr)) { return valStr; }
+  if (/^-?\d+$/.test(valStr)) { return valStr; }
   return value;
 };
 
@@ -92,7 +102,7 @@ var parseJsonArray = function(value) {
     return arr;
   }
 
-  return arr.map(function(el) { return JSON.parse(el); });
+  return arr.map(function(el) { return safeParseJson(el); });
 };
 
 var parsePoint = function(value) {
@@ -166,8 +176,8 @@ var init = function(register) {
   register(1185, parseDateArray); // timestamp with time zone[]
   register(1186, parseInterval);
   register(17, parseByteA);
-  register(114, JSON.parse.bind(JSON)); // json
-  register(3802, JSON.parse.bind(JSON)); // jsonb
+  register(114, safeParseJson); // json
+  register(3802, safeParseJson); // jsonb
   register(199, parseJsonArray); // json[]
   register(3807, parseJsonArray); // jsonb[]
   register(2951, parseStringArray); // uuid[]

--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -5,7 +5,7 @@ var parseDate = require('postgres-date');
 var parseInterval = require('postgres-interval');
 var parseByteA = require('postgres-bytea');
 
-var intToStringRegex = new RegExp('("[^"]+":\\s*)(-?\\d+)', 'g');
+var intToStringRegex = new RegExp('("[^"]+"\\s*:\\s*)(-?\\d+)', 'g');
 
 function allowNull (fn) {
   return function nullAllowed (value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pg-types",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Query result type converters for node-postgres",
   "main": "index.js",
   "scripts": {

--- a/test/types.js
+++ b/test/types.js
@@ -301,6 +301,22 @@ exports['array/date'] = {
   ]
 }
 
+exports['json/int8'] = {
+  format: 'text',
+  id: 114,
+  tests: [
+    [
+      '{"id": -9223372036854775808, "another_big_int": -9223372036854775807}',
+      function (t, value) {
+        t.deepEqual(value, {
+          id: "-9223372036854775808",
+          another_big_int: "-9223372036854775807"
+        })
+      }
+    ]
+  ]
+}
+
 exports['binary-string/varchar'] = {
   format: 'binary',
   id: 1043,


### PR DESCRIPTION
Currently, this library does not parse INT by default given that it will truncate a BIGINT of full size.

However, in the case of nested JSON columns, the string from postgres is being passed straight into JSON.parse, which immediately truncates the values.  Other than overriding JSON.parse (a terrible choice), my solution is to do a string replace on the JSON string to convert the integer values into strings.

Unfortunately, there isn't really a good way to check if this process even needs to occur before it does, so it will lead to a slight performance degradation.  It also causes an API level behavioral change