### PR TITLE
Require statement breaks Browserify compatibility

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -1,6 +1,6 @@
 var array = require('postgres-array')
 var ap = require('ap')
-var arrayParser = require(__dirname + "/arrayParser.js");
+var arrayParser = require('./arrayParser');
 var parseDate = require('postgres-date');
 var parseInterval = require('postgres-interval');
 var parseByteA = require('postgres-bytea');


### PR DESCRIPTION
Using `__dirname` in require statements breaks compatibility with Browserify.