### PR TITLE
Register oid array to be parsed as integer array

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -153,6 +153,7 @@ var init = function(register) {
   register(1001, parseByteAArray);
   register(1005, parseIntegerArray); // _int2
   register(1007, parseIntegerArray); // _int4
+  register(1028, parseIntegerArray); // oid[]
   register(1016, parseBigIntegerArray); // _int8
   register(1021, parseFloatArray); // _float4
   register(1022, parseFloatArray); // _float8

--- a/test/types.js
+++ b/test/types.js
@@ -262,6 +262,16 @@ exports['array/int8'] = {
   ]
 }
 
+exports['array/oid'] = {
+  format: 'text',
+  id: 1028,
+  tests: [
+    ['{25864,25860}', function (t, value) {
+      t.deepEqual(value, [25864, 25860])
+    }]
+  ]
+}
+
 exports['array/float4'] = {
   format: 'text',
   id: 1021,


### PR DESCRIPTION
Add OID[] as a type registered to be parsed, using the integer array parser