### PR TITLE
Proposed solution to issue #50

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -1,7 +1,7 @@
 var array = require('postgres-array')
 var ap = require('ap')
 var arrayParser = require('./arrayParser');
-var parseDate = require('postgres-date');
+var parseTimestamp = require('postgres-date');
 var parseInterval = require('postgres-interval');
 var parseByteA = require('postgres-bytea');
 
@@ -59,6 +59,19 @@ var parseDateArray = function(value) {
   var p = arrayParser.create(value, function(entry) {
     if (entry !== null) {
       entry = parseDate(entry);
+    }
+    return entry;
+  });
+
+  return p.parse();
+};
+
+var parseTimestampArray = function(value) {
+  if (!value) { return null; }
+
+  var p = arrayParser.create(value, function(entry) {
+    if (entry !== null) {
+      entry = parseTimestamp(entry);
     }
     return entry;
   });
@@ -136,6 +149,10 @@ var parseCircle = function(value) {
   return result;
 };
 
+var parseDate = function(value) {
+  return value;
+}
+
 var init = function(register) {
   register(20, parseBigInteger); // int8
   register(21, parseInteger); // int2
@@ -145,8 +162,8 @@ var init = function(register) {
   register(701, parseFloat); // float8/double
   register(16, parseBool);
   register(1082, parseDate); // date
-  register(1114, parseDate); // timestamp without timezone
-  register(1184, parseDate); // timestamp
+  register(1114, parseTimestamp); // timestamp without timezone
+  register(1184, parseTimestamp); // timestamp
   register(600, parsePoint); // point
   register(718, parseCircle); // circle
   register(1000, parseBoolArray);
@@ -162,9 +179,9 @@ var init = function(register) {
   register(1015, parseStringArray); //varchar
   register(1008, parseStringArray);
   register(1009, parseStringArray);
-  register(1115, parseDateArray); // timestamp without time zone[]
+  register(1115, parseTimestampArray); // timestamp without time zone[]
   register(1182, parseDateArray); // _date
-  register(1185, parseDateArray); // timestamp with time zone[]
+  register(1185, parseTimestampArray); // timestamp with time zone[]
   register(1186, parseInterval);
   register(17, parseByteA);
   register(114, JSON.parse.bind(JSON)); // json

--- a/test/types.js
+++ b/test/types.js
@@ -103,7 +103,7 @@ exports.timestamp = {
   id: 1114,
   tests: [
     [
-      '2010-10-31 00:00:00', 
+      '2010-10-31 00:00:00',
       function (t, value) {
         t.equal(
           value.toUTCString(),
@@ -122,15 +122,7 @@ exports.date = {
   format: 'text',
   id: 1082,
   tests: [
-    ['2010-10-31', function (t, value) {
-      var now = new Date(2010, 9, 31)
-      dateEquals(
-        2010,
-        now.getUTCMonth(),
-        now.getUTCDate(),
-        now.getUTCHours(), 0, 0, 0)(t, value)
-      t.equal(value.getHours(), now.getHours())
-    }]
+    ['2010-10-31', '2010-10-31']
   ]
 }
 
@@ -297,17 +289,9 @@ exports['array/date'] = {
   id: 1182,
   tests: [
     ['{2014-01-01,2015-12-31}', function (t, value) {
-      var expecteds = [new Date(2014, 0, 1), new Date(2015, 11, 31)]
-      t.equal(value.length, 2)
-      value.forEach(function (date, index) {
-        var expected = expecteds[index]
-        dateEquals(
-          expected.getUTCFullYear(),
-          expected.getUTCMonth(),
-          expected.getUTCDate(),
-          expected.getUTCHours(), 0, 0, 0)(t, date)
-      })
-    }]
+        t.deepEqual(value, ['2014-01-01', '2015-12-31'])
+      }
+    ]
   ]
 }
 


### PR DESCRIPTION
Timestamps are now parsed differently from YYYY-MM-DD date strings. Value is returned unchanged.

Please see #50 
