### PR TITLE
Add test for BOOL[] type oid:1000

### DIFF
--- a/test/types.js
+++ b/test/types.js
@@ -171,6 +171,16 @@ exports.bytea = {
   ]
 }
 
+exports['array/boolean'] = {
+    format: 'text',
+    id: 1000,
+    tests: [
+        ['{true,false}', function (t, value) {
+            t.deepEqual(value, [true, false])
+        }]
+    ]
+}
+
 exports['array/char'] = {
   format: 'text',
   id: 1014,


### PR DESCRIPTION
This is to increase coverage for the BOOL[] type.  Currently this test fails due to an issue with postgres-array [here](https://github.com/bendrucker/postgres-array/pull/3).  This is just to have coverage going forward.

Thanks!
