### PR TITLE
Optimize parseIntegerArray

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -1,5 +1,4 @@
 var array = require('postgres-array')
-var ap = require('ap')
 var arrayParser = require('./arrayParser');
 var parseDate = require('postgres-date');
 var parseInterval = require('postgres-interval');
@@ -28,9 +27,13 @@ function parseBoolArray (value) {
   return array.parse(value, parseBool)
 }
 
+function parseBaseTenInt (string) {
+  return parseInt(string, 10)
+}
+
 function parseIntegerArray (value) {
   if (!value) return null
-  return array.parse(value, allowNull(ap.partialRight(parseInt, 10)))
+  return array.parse(value, allowNull(parseBaseTenInt))
 }
 
 function parseBigIntegerArray (value) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "ap": "~0.2.0",
     "postgres-array": "~1.0.0",
     "postgres-bytea": "~1.0.0",
     "postgres-date": "~1.0.0",


### PR DESCRIPTION
While profiling hot code paths in my application I noticed that ap.partialRight was not being optimized by V8. See the following line from running with `--trace-opt`:
```
[disabled optimization for 0xc46b2b55d91 <SharedFunctionInfo partialRight>, reason: Bad value context for arguments value]
```

Doing the currying by hand results in a ~60% performance improvement. I used the following simple script to benchmark:
```
var getTypeParser = require('.').getTypeParser

var parser = getTypeParser(1005, 'text')

console.time('test')
for (var i = 0; i < 100000; i++) {
    parser('{-2147483648, -2147483647, 2147483646, 2147483647}')
}
console.timeEnd('test')
```

Since the dependency `ap` was only being used in `parseIntegerArray`, I removed it. Of course, I'm open to any questions or feedback you may have. Thanks!