### PR TITLE
Restore int8 binary parser

### DIFF
--- a/lib/binaryParsers.js
+++ b/lib/binaryParsers.js
@@ -1,3 +1,5 @@
+var parseInt64 = require('pg-int8');
+
 var parseBits = function(data, bits, offset, invert, callback) {
   offset = offset || 0;
   invert = invert || false;
@@ -232,6 +234,7 @@ var parseBool = function(value) {
 };
 
 var init = function(register) {
+  register(20, parseInt64);
   register(21, parseInt16);
   register(23, parseInt32);
   register(26, parseInt32);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
+    "pg-int8": "1.0.0",
     "postgres-array": "~1.0.0",
     "postgres-bytea": "~1.0.0",
     "postgres-date": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "pg-int8": "1.0.0",
+    "pg-int8": "1.0.1",
     "postgres-array": "~1.0.0",
     "postgres-bytea": "~1.0.0",
     "postgres-date": "~1.0.0",

--- a/test/types.js
+++ b/test/types.js
@@ -473,6 +473,14 @@ exports['binary-smallint/int2'] = {
   ]
 }
 
+exports['binary-bigint/int8'] = {
+  format: 'binary',
+  id: 20,
+  tests: [
+    [new Buffer([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]), '9223372036854775807']
+  ]
+}
+
 exports['binary-oid'] = {
   format: 'binary',
   id: 26,


### PR DESCRIPTION
Removed in <https://github.com/brianc/node-postgres/commit/fb5520bb8a22438a4885aef9c9ef95edfa9d73e7>; reimplemented here without native add-ons.

An exact-version dependency on a package with two easy-to-audit files:

```shellsession
$ npm info pg-int8 dist
{ integrity: 'sha512-5SojTTxi9rTObWGqfcsPd/+uyU4ctsmChLhqQVTzzc9ltDsWni1TJuYwX/lJMDFdGgd9lVgkXcDyQvRIgI5elw==',
  shasum: 'd93de9931d87b24be674febc0fdaac6d52701de5',
  tarball: 'https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.0.tgz' }
$ wget https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.0.tgz
⋮
$ tar tf pg-int8-1.0.0.tgz 
package/package.json
package/index.js
package/LICENSE
package/README.md
```

See also https://github.com/brianc/node-postgres/issues/1492#issuecomment-344131130.