### PR TITLE
update postgres-array to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
+  - 'lts/*'
   - 'node'
 env:
   - PGUSER=postgres

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
   },
   "dependencies": {
     "pg-int8": "1.0.1",
-    "postgres-array": "~1.0.0",
+    "postgres-array": "~2.0.0",
     "postgres-bytea": "~1.0.0",
     "postgres-date": "~1.0.0",
     "postgres-interval": "^1.1.0"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
Adds support for handling array dimensions (by discarding) in https://github.com/bendrucker/postgres-array/pull/6

I've added an engine here to match pg and postgres-array and updated Travis to match. This should be published as a major version to be safe. Then pg can just get a patch update that makes the update to types.

@brianc I don't have publish rights on this package (or pg), let me know if you'd rather add me or publish yourself