### PR TITLE
Depend explicitly on postgres-date ~1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pg-int8": "1.0.1",
     "postgres-array": "~2.0.0",
     "postgres-bytea": "~1.0.0",
-    "postgres-date": "~1.0.0",
+    "postgres-date": "~1.0.4",
     "postgres-interval": "^1.1.0"
   },
   "engines": {


### PR DESCRIPTION
Fixes for BC dates and one or two other edge cases were merged in bendrucker/postgres-date#6 and published in 1.0.4.

One integration test in node-postgres already needs changing as a result, so the depended behaviour should obviously be consistent so the test won't be flaky.

1.0.4 is also basically a prerequisite for brianc/node-postgres#1864, assuming round trips with BC dates should succeed.

There is one test failure in *this* package, but it's unrelated (was already failing on master). Edit: I opened a separate PR to fix that.