### PR TITLE
fix: Normalize handling of numeric and numeric[] types

### DIFF
--- a/lib/binaryParsers.js
+++ b/lib/binaryParsers.js
@@ -114,7 +114,7 @@ var parseFloat64 = function(value) {
 var parseNumeric = function(value) {
   var sign = parseBits(value, 16, 32);
   if (sign == 0xc000) {
-    return NaN;
+    return 'NaN';
   }
 
   var weight = Math.pow(10000, parseBits(value, 16, 16));
@@ -128,7 +128,8 @@ var parseNumeric = function(value) {
   }
 
   var scale = Math.pow(10, parseBits(value, 16, 48));
-  return ((sign === 0) ? 1 : -1) * Math.round(result * scale) / scale;
+  var ret = ((sign === 0) ? 1 : -1) * Math.round(result * scale) / scale;
+  return '' + ret;
 };
 
 var parseDate = function(isUTC, value) {

--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -186,7 +186,7 @@ var init = function(register) {
   register(1017, parsePointArray); // point[]
   register(1021, parseFloatArray); // _float4
   register(1022, parseFloatArray); // _float8
-  register(1231, parseFloatArray); // _numeric
+  register(1231, parseStringArray); // _numeric
   register(1014, parseStringArray); //char
   register(1015, parseStringArray); //varchar
   register(1008, parseStringArray);

--- a/test/types.js
+++ b/test/types.js
@@ -289,7 +289,7 @@ exports['array/numeric'] = {
   id: 1231,
   tests: [
     ['{1.2,3.4}', function (t, value) {
-      t.deepEqual(value, [1.2, 3.4])
+      t.deepEqual(value, ['1.2', '3.4'])
     }]
   ]
 }
@@ -531,7 +531,7 @@ exports['binary-numeric'] = {
   tests: [
     [
       [0, 2, 0, 0, 0, 0, 0, hex('0x64'), 0, 12, hex('0xd'), hex('0x48'), 0, 0, 0, 0],
-      12.34
+      '12.34'
     ]
   ]
 }


### PR DESCRIPTION
Normalizes handling of numeric and numeric[] types to always return a string representation of the value for both the text and binary protocols.

Closes out #86

It's a bit of a hack as it's just converting the numeric representation to a string but seemed like the lowest impact way of making the change. Ideally the parsing logic could be tightened up to directly generate the string in a manner similar to what the backend does (see numeric_recv here: https://doxygen.postgresql.org/backend_2utils_2adt_2numeric_8c.html#a3ae98a87bbc2d0dfc9cbe3d5845e0035). I've got a WIP to handle things that way but it's a lot more code and would need more rigorous test vectors so will have to wait a bit.