### PR TITLE
test: Convert binary test vectors via Buffer.from(...)

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,13 @@ test('types', function (t) {
       var parser = getTypeParser(type.id, type.format)
       type.tests.forEach(function (tests) {
         var input = tests[0]
+        if (type.format === 'binary' && input !== null && !Buffer.isBuffer(input)) {
+          if (Array.isArray(input) || typeof(input) === 'string') {
+            input = Buffer.from(input)
+          } else {
+            throw new Error('Binary test inputs must be null, a String, a Buffer, or an Array')
+          }
+        }
         var expected = tests[1]
         var result = parser(input)
         if (typeof expected === 'function') {


### PR DESCRIPTION
While working on a more direct handling of a fix for #86 I noticed that some of the binary protocol test vectors are not actually Buffers. The parser code mostly treats things as arrays so it does not break anything for now but ran into an issue trying to use Buffer functions like `readInt16BE(...)` in new code.

This PR leaves the tests alone but automatically converts anything that's not a Buffer to one prior to running a binary format test. I think this is a nice compromise as the parser code can rely on its contract of the input value being a Buffer and the test code can continue to use shorthand like `[1,2,3,4]` for a 4-byte array rather than changing everything to `Buffer.from(...)`.