### PR TITLE
fix: Normalize text protocol handling of numeric and numeric[] types

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -186,7 +186,7 @@ var init = function(register) {
   register(1017, parsePointArray); // point[]
   register(1021, parseFloatArray); // _float4
   register(1022, parseFloatArray); // _float8
-  register(1231, parseFloatArray); // _numeric
+  register(1231, parseStringArray); // _numeric
   register(1014, parseStringArray); //char
   register(1015, parseStringArray); //varchar
   register(1008, parseStringArray);

--- a/test/types.js
+++ b/test/types.js
@@ -289,7 +289,7 @@ exports['array/numeric'] = {
   id: 1231,
   tests: [
     ['{1.2,3.4}', function (t, value) {
-      t.deepEqual(value, [1.2, 3.4])
+      t.deepEqual(value, ['1.2', '3.4'])
     }]
   ]
 }


### PR DESCRIPTION
__NOTE:__ This does not fix the binary protocol, only the text one.