### PR TITLE
misc: Add explicit file list to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
     "postgres-date": "~1.0.4",
     "postgres-interval": "^1.1.0"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib"
+  ],
   "engines": {
     "node": ">=4"
   }


### PR DESCRIPTION
Adds explicit list of files to include in the final published module. Otherwise the tests, Travis config,  Makefile, etc will be included. Size difference isn't much but no point in including them.

FYI, the README is not explicitly added as npm will include it regardless.

## Before

```
$ npm pack
npm notice 
npm notice 📦  pg-types@2.2.0
npm notice === Tarball Contents === 
npm notice 973B   package.json        
npm notice 83B    .travis.yml         
npm notice 2.6kB  index.d.ts          
npm notice 1.2kB  index.js            
npm notice 759B   index.test-d.ts     
npm notice 232B   Makefile            
npm notice 3.8kB  README.md           
npm notice 208B   lib/arrayParser.js  
npm notice 6.1kB  lib/binaryParsers.js
npm notice 1.6kB  lib/builtins.js     
npm notice 5.4kB  lib/textParsers.js  
npm notice 644B   test/index.js       
npm notice 11.7kB test/types.js       
npm notice === Tarball Details === 
npm notice name:          pg-types                                
npm notice version:       2.2.0                                   
npm notice filename:      pg-types-2.2.0.tgz                      
npm notice package size:  10.3 kB                                 
npm notice unpacked size: 35.3 kB                                 
npm notice shasum:        d52b0cf4cb81ab36dc9bc76c0a241f6e82461375
npm notice integrity:     sha512-ZUJ1UBqcpOeRi[...]G4q75sNA7uK/w==
npm notice total files:   13                                      
npm notice 
pg-types-2.2.0.tgz
```

## After

```
$ npm pack
npm notice 
npm notice 📦  pg-types@2.2.0
npm notice === Tarball Contents === 
npm notice 1.0kB package.json        
npm notice 2.6kB index.d.ts          
npm notice 1.2kB index.js            
npm notice 3.8kB README.md           
npm notice 208B  lib/arrayParser.js  
npm notice 6.1kB lib/binaryParsers.js
npm notice 1.6kB lib/builtins.js     
npm notice 5.4kB lib/textParsers.js  
npm notice === Tarball Details === 
npm notice name:          pg-types                                
npm notice version:       2.2.0                                   
npm notice filename:      pg-types-2.2.0.tgz                      
npm notice package size:  7.1 kB                                  
npm notice unpacked size: 21.9 kB                                 
npm notice shasum:        ba70b34242a19a2411d843a809207ea900e64587
npm notice integrity:     sha512-+vtRcb+Spen0t[...]Ko6/lk0WGaL1A==
npm notice total files:   8                                       
npm notice 
pg-types-2.2.0.tgz
```
