### PR TITLE
Solidify existing UTF-8 decoding behaviour on binary-format text[]

### DIFF
--- a/lib/binaryParsers.js
+++ b/lib/binaryParsers.js
@@ -191,7 +191,7 @@ var parseArray = function (value) {
       return result
     } else if (elementType === 0x19) {
       // string
-      result = value.toString(this.encoding, offset >> 3, (offset += (length << 3)) >> 3)
+      result = value.toString('utf8', offset >> 3, (offset += (length << 3)) >> 3)
       return result
     } else {
       throw new Error('ElementType not implemented: ' + elementType)


### PR DESCRIPTION
This never did the right thing, even when it was introduced back in brianc/node-postgres@5b3c501d74d0b3d1610dadf776c746a956537925, reading from the global object instead of the client. It’ll usually be undefined and result in UTF-8 decoding, but when it isn’t…

```js
> const {Client} = require('pg');
> const client = new Client();
> await client.connect();
> encoding = 'base64';
> (await client.query({text: "SELECT 'foo' x WHERE $1 = 1", values: [1], binary: true})).rows
[ { x: 'foo' } ]
> (await client.query({text: "SELECT ARRAY['foo'] x WHERE $1 = 1", values: [1], binary: true})).rows
[ { x: [ 'Zm9v' ] } ]
```

UTF-8 matches the non-array binary parser for the text type.