### PR TITLE
Simplify binary parsing using built-in Buffer methods

### DIFF
--- a/lib/binaryParsers.js
+++ b/lib/binaryParsers.js
@@ -1,124 +1,27 @@
 var parseInt64 = require('pg-int8')
 var parseNumeric = require('pg-numeric')
 
-var parseBits = function (data, bits, offset, invert, callback) {
-  offset = offset || 0
-  invert = invert || false
-  callback = callback || function (lastValue, newValue, bits) { return (lastValue * Math.pow(2, bits)) + newValue }
-  var offsetBytes = offset >> 3
-
-  var inv = function (value) {
-    if (invert) {
-      return ~value & 0xff
-    }
-
-    return value
-  }
-
-  // read first (maybe partial) byte
-  var mask = 0xff
-  var firstBits = 8 - (offset % 8)
-  if (bits < firstBits) {
-    mask = (0xff << (8 - bits)) & 0xff
-    firstBits = bits
-  }
-
-  if (offset) {
-    mask = mask >> (offset % 8)
-  }
-
-  var result = 0
-  if ((offset % 8) + bits >= 8) {
-    // eslint-disable-next-line standard/no-callback-literal
-    result = callback(0, inv(data[offsetBytes]) & mask, firstBits)
-  }
-
-  // read bytes
-  var bytes = (bits + offset) >> 3
-  for (var i = offsetBytes + 1; i < bytes; i++) {
-    result = callback(result, inv(data[i]), 8)
-  }
-
-  // bits to read, that are not a complete byte
-  var lastBits = (bits + offset) % 8
-  if (lastBits > 0) {
-    result = callback(result, inv(data[bytes]) >> (8 - lastBits), lastBits)
-  }
-
-  return result
-}
-
-var parseFloatFromBits = function (data, precisionBits, exponentBits) {
-  var bias = Math.pow(2, exponentBits - 1) - 1
-  var sign = parseBits(data, 1)
-  var exponent = parseBits(data, exponentBits, 1)
-
-  if (exponent === 0) {
-    return 0
-  }
-
-  // parse mantissa
-  var precisionBitsCounter = 1
-  var parsePrecisionBits = function (lastValue, newValue, bits) {
-    if (lastValue === 0) {
-      lastValue = 1
-    }
-
-    for (var i = 1; i <= bits; i++) {
-      precisionBitsCounter /= 2
-      if ((newValue & (0x1 << (bits - i))) > 0) {
-        lastValue += precisionBitsCounter
-      }
-    }
-
-    return lastValue
-  }
-
-  var mantissa = parseBits(data, precisionBits, exponentBits + 1, false, parsePrecisionBits)
-
-  // special cases
-  if (exponent === (Math.pow(2, exponentBits + 1) - 1)) {
-    if (mantissa === 0) {
-      return (sign === 0) ? Infinity : -Infinity
-    }
-
-    return NaN
-  }
-
-  // normale number
-  return ((sign === 0) ? 1 : -1) * Math.pow(2, exponent - bias) * mantissa
-}
-
 var parseInt16 = function (value) {
-  if (parseBits(value, 1) === 1) {
-    return -1 * (parseBits(value, 15, 1, true) + 1)
-  }
-
-  return parseBits(value, 15, 1)
+  return value.readInt16BE(0)
 }
 
 var parseInt32 = function (value) {
-  if (parseBits(value, 1) === 1) {
-    return -1 * (parseBits(value, 31, 1, true) + 1)
-  }
-
-  return parseBits(value, 31, 1)
+  return value.readInt32BE(0)
 }
 
 var parseFloat32 = function (value) {
-  return parseFloatFromBits(value, 23, 8)
+  return value.readFloatBE(0)
 }
 
 var parseFloat64 = function (value) {
-  return parseFloatFromBits(value, 52, 11)
+  return value.readDoubleBE(0)
 }
 
 var parseDate = function (isUTC, value) {
-  var sign = parseBits(value, 1)
-  var rawValue = parseBits(value, 63, 1)
+  var rawValue = 0x100000000 * value.readInt32BE(0) + value.readUInt32BE(4)
 
   // discard usecs and shift from 2000 to 1970
-  var result = new Date((((sign === 0) ? 1 : -1) * rawValue / 1000) + 946684800000)
+  var result = new Date((rawValue / 1000) + 946684800000)
 
   if (!isUTC) {
     result.setTime(result.getTime() + result.getTimezoneOffset() * 60000)
@@ -212,7 +115,7 @@ var parseText = function (value) {
 
 var parseBool = function (value) {
   if (value === null) return null
-  return (parseBits(value, 8) > 0)
+  return value[0] !== 0
 }
 
 var init = function (register) {


### PR DESCRIPTION
instead of `parseBits`. Probably improves performance quite a bit, too.