### PR TITLE
Upgrade pg-numeric to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "pg-int8": "1.0.1",
-    "pg-numeric": "1.0.1",
+    "pg-numeric": "1.0.2",
     "postgres-array": "~2.0.0",
     "postgres-bytea": "~1.0.0",
     "postgres-date": "~1.0.4",


### PR DESCRIPTION
Fixes an important correctness bug (https://github.com/charmander/pg-numeric/blob/master/CHANGELOG.md#102--2019-11-10).