### PR TITLE
Remove arrayParser export from TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -76,12 +76,3 @@ export function setTypeParser<T>(oid: number | TypeId, format: 'binary', parseFn
 export function getTypeParser<T>(oid: number | TypeId): TypeParser<string, T | string>;
 export function getTypeParser<T>(oid: number | TypeId, format: 'text'): TypeParser<string, T | string>;
 export function getTypeParser<T>(oid: number | TypeId, format: 'binary'): TypeParser<Buffer, T | string>;
-
-interface ArrayParser<T> {
-  parse(): ReadonlyArray<T>;
-}
-
-export namespace arrayParser {
-  function create<T>(source: string): ArrayParser<string>;
-  function create<T>(source: string, transform: TypeParser<string, T>): ArrayParser<T>;
-}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -20,10 +20,6 @@ expectType<boolean | string>(booleanParser2('f'));
 const numericParser = types.getTypeParser<number>(types.builtins.NUMERIC, 'binary');
 expectType<number | string>(numericParser(Buffer.from([200, 1, 0, 15])));
 
-// arrayParser
-const value = types.arrayParser.create('{1,2,3}', (num: string): number => Number.parseInt(num)).parse();
-expectType<ReadonlyArray<number>>(value);
-
 // setTypeParser
 types.setTypeParser(types.builtins.INT8, Number.parseInt);
 types.setTypeParser(types.builtins.FLOAT8, Number.parseFloat);


### PR DESCRIPTION
https://github.com/brianc/node-pg-types/commit/0d2ea808cbe9cf31d2175f0a6ca6cd2cea3a824f removed the `arrayParser` export but the TypeScript definitions where not updated.