### PR TITLE
Remove null checks

### DIFF
--- a/lib/binaryParsers.js
+++ b/lib/binaryParsers.js
@@ -98,7 +98,6 @@ var parseText = function (value) {
 }
 
 var parseBool = function (value) {
-  if (value === null) return null
   return value[0] !== 0
 }
 

--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -4,7 +4,6 @@ var parseInterval = require('postgres-interval')
 var parseByteA = require('postgres-bytea')
 
 function parseBool (value) {
-  if (value === null) return value
   return value === 'TRUE' ||
     value === 't' ||
     value === 'true' ||
@@ -15,7 +14,6 @@ function parseBool (value) {
 }
 
 function parseBoolArray (value) {
-  if (!value) return null
   return array.parse(value, parseBool)
 }
 
@@ -24,29 +22,24 @@ function parseBaseTenInt (string) {
 }
 
 function parseIntegerArray (value) {
-  if (!value) return null
   return array.parse(value, parseBaseTenInt)
 }
 
 function parseBigIntegerArray (value) {
-  if (!value) return null
   return array.parse(value, function (entry) {
     return parseBigInteger(entry).trim()
   })
 }
 
 var parsePointArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, parsePoint)
 }
 
 var parseFloatArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, parseFloat)
 }
 
 var parseStringArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, undefined)
 }
 
@@ -67,12 +60,10 @@ var parseTimestampTzArray = function (value) {
 }
 
 var parseIntervalArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, parseInterval)
 }
 
 var parseByteAArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, parseByteA)
 }
 
@@ -83,7 +74,6 @@ var parseBigInteger = function (value) {
 }
 
 var parseJsonArray = function (value) {
-  if (!value) { return null }
   return array.parse(value, JSON.parse)
 }
 

--- a/test/types.js
+++ b/test/types.js
@@ -76,8 +76,7 @@ exports.boolean = {
     ['yes', true],
     ['on', true],
     ['1', true],
-    ['f', false],
-    [null, null]
+    ['f', false]
   ]
 }
 
@@ -542,8 +541,7 @@ exports['binary-boolean'] = {
   id: 16,
   tests: [
     [[1], true],
-    [[0], false],
-    [null, null]
+    [[0], false]
   ]
 }
 


### PR DESCRIPTION
They’re applied inconsistently (not all parsers include them) and can easily be done by the caller (like pg already does).