### PR TITLE
Specify radix in bigint example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Let's do something I commonly like to do on projects: return 64-bit integers `(i
 ```js
 var types = require('pg').types
 types.setTypeParser(20, function(val) {
-  return parseInt(val)
+  return parseInt(val, 10)
 })
 ```
 


### PR DESCRIPTION
Not a huge deal but specifying the radix is generally recommended, and its omission might trigger various linter rules:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Octal_interpretations_with_no_radix