### PR TITLE
perf: prefer parse int with + instead parseInt()

### DIFF
--- a/lib/textParsers.js
+++ b/lib/textParsers.js
@@ -18,12 +18,8 @@ function parseBoolArray (value) {
   return array.parse(value, parseBool)
 }
 
-function parseBaseTenInt (string) {
-  return parseInt(string, 10)
-}
-
 function parseIntegerArray (value) {
-  return array.parse(value, parseBaseTenInt)
+  return array.parse(value, Number)
 }
 
 function parseBigIntegerArray (value) {
@@ -120,7 +116,7 @@ const parseCircle = function (value) {
 }
 
 function parseInt4Range (raw) {
-  return range.parse(raw, parseBaseTenInt)
+  return range.parse(raw, Number)
 }
 
 function parseNumRange (raw) {
@@ -141,9 +137,9 @@ function parseTimestampTzRange (raw) {
 
 const init = function (register) {
   register(20, parseBigInteger) // int8
-  register(21, parseBaseTenInt) // int2
-  register(23, parseBaseTenInt) // int4
-  register(26, parseBaseTenInt) // oid
+  register(21, Number) // int2
+  register(23, Number) // int4
+  register(26, Number) // oid
   register(700, parseFloat) // float4/real
   register(701, parseFloat) // float8/double
   register(16, parseBool)


### PR DESCRIPTION
Closes #141

Based on [nodejs-benchmarks](https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/v19/RESULTS-v19_6_0.md#parsing-integer) about `parseInt` and `+` operator, using `+` is way faster than `parseInt` for large numbers.

Here's the benchmark with the new parser:

```
Using parseInt(x, 10) - small number (2 len) x 300,130,498 ops/sec ±1.74% (92 runs sampled)
Using parseInt(x, 10) - big number (10 len) x 16,455,360 ops/sec ±1.38% (95 runs sampled)
Using + - small number (2 len) x 1,130,810,993 ops/sec ±0.59% (94 runs sampled)
Using + - big number (10 len) x 1,141,065,805 ops/sec ±0.08% (97 runs sampled)
```

<details>
<summary>Benchmark</summary>

```js
const Benchmark = require('benchmark')
const suite = new Benchmark.Suite;

function parseIntegerV1 (string) {
  return parseInt(string, 10);
}

function parseIntegerV2 (string) {
  if (string === '' || string === undefined || string === null) {
    return NaN
  }

  return +string
}

suite
.add('Using parseInt(x, 10) - small number (2 len)', function () {
  parseIntegerV1('5', 10)
})
.add('Using parseInt(x, 10) - big number (10 len)', function () {
  parseIntegerV1('9999999999', 10)
})
.add('Using + - small number (2 len)', function () {
  parseIntegerV2('5')
})
.add('Using + - big number (10 len)', function () {
  parseIntegerV2('9999999999')
})
.on('cycle', function(event) {
  console.log(String(event.target))
})
.run({ 'async': false });
```

</details>
