### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postgres-bytea": "~3.0.0",
     "postgres-date": "~2.0.1",
     "postgres-interval": "^3.0.0",
-    "postgres-range": "^1.1.1"
+    "postgres-range": "^1.1.3"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "pg-int8": "1.0.1",
     "pg-numeric": "1.0.2",
-    "postgres-array": "~3.0.1",
+    "postgres-array": "~3.0.2",
     "postgres-bytea": "~3.0.0",
     "postgres-date": "~2.0.1",
     "postgres-interval": "^3.0.0",


### PR DESCRIPTION
Just bump the dependencies, especially for `postgres-array` after improvement performance at https://github.com/bendrucker/postgres-array/pull/16.