### PR TITLE
Clean up GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: yarn install # --frozen-lockfile TODO get this option working
-      - run: yarn test-ts
+      - run: npm install
+      - run: npm run test-ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: yarn
-      - run: yarn install # --frozen-lockfile TODO get this option working
-      - run: yarn test
+      - run: npm install
+      - run: npm test
+
   test-ts:
     timeout-minutes: 2
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,24 +46,12 @@ jobs:
   types:
     timeout-minutes: 2
     runs-on: ubuntu-latest
-    needs: lint
-    strategy:
-      fail-fast: false
-      matrix:
-        node:
-          - '12'
-          - '14'
-          - '16'
-          - '18'
-          - '20'
-    name: test ts - node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
-          cache: yarn
+          node-version: '20'
       - run: yarn install # --frozen-lockfile TODO get this option working
       - run: yarn test-ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          cache: yarn
-      - run: yarn install # --frozen-lockfile TODO get this option working
-      - run: yarn lint
+          node-version: 20
+      - run: npm install
+      - run: npm run lint
+
   test-js:
     timeout-minutes: 2
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm install
       - run: npm run lint
 
-  test-js:
+  test:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     strategy:
@@ -43,7 +43,7 @@ jobs:
       - run: npm install
       - run: npm test
 
-  test-ts:
+  types:
     timeout-minutes: 2
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
           - '16'
           - '18'
           - '20'
-    name: test js - node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
           - '20'
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
   test-js:
     timeout-minutes: 2
     runs-on: ubuntu-latest
-    needs: lint
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "coverage": "nyc --reporter=html npm test && open-cli coverage/index.html",
     "coverage-ci": "nyc --reporter=lcov npm test && codecov",
     "lint": "standard",
-    "test": "tape test/*.js | tap-spec && npm run test-ts && npm run lint",
+    "test": "npm run test-js && npm run test-ts && npm run lint",
+    "test-js": "tape test/*.js | tap-spec",
     "test-ts": "tsd"
   },
   "repository": {


### PR DESCRIPTION
Fixes some issues from #152 

* Duplicate trigger when opening PRs from this repo (no fork)
* Remove Yarn, `npm` is just fine
* Lint on latest LTS only
* Test always, even if lint fails
* Don't check types on multiple Node versions
* Remove useless `actions/checkout` option (workflow only has read permissions so `persist-credentials: false` is unimportant)