### PR TITLE
test: only run JS tests in test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npm test
+      - run: npm run test-js
 
   types:
     timeout-minutes: 2


### PR DESCRIPTION
Avoid also running `lint` and `test-ts` scripts