### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
-    "pg-int8": "1.0.1",
-    "pg-numeric": "1.0.2",
-    "postgres-array": "~3.0.1",
+    "pg-int8": "^1.0.1",
+    "pg-numeric": "^1.0.2",
+    "postgres-array": "~3.0.2",
     "postgres-bytea": "~3.0.0",
     "postgres-date": "~2.1.0",
-    "postgres-interval": "^3.0.0",
-    "postgres-range": "^1.1.1"
+    "postgres-interval": "^4.0.2",
+    "postgres-range": "^1.1.4"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Some old dependencies here drag in more and obsolete dependencies, like the old `postgres-interval` drags in the obsolete `xtend`, for instance.
